### PR TITLE
Update programs_list.yml

### DIFF
--- a/programs_list.yml
+++ b/programs_list.yml
@@ -45,6 +45,7 @@
       - MMath@Waterloo
     NONCS:
       - MDSAI@Waterloo
+      - MITS@CMU
       - ECE Meng(coop)@Waterloo
       - ECE@UT Austin
 - A:
@@ -66,7 +67,6 @@
     NONCS:
       - EC79@UCSD
       - MSMITE@CMU
-      - MITS@CMU
       - DS@Columbia
       - CSDA@Dartmouth
       - ECE@Duke


### PR DESCRIPTION
MITS was misplaced because of branch merges https://github.com/csmsapp/csmsapp.github.io/commit/e10edc40efd6b7f1bdc611ed6b630cb93e0e6d60. Students admitted to MITS usually have offers from Yale one-year CS master, Stanford MSCS, etc. If applied at A- level, they will have a high probability of being rejected.